### PR TITLE
More integration test adjustments.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,13 @@ jobs:
       - name: Start SNMP Container
         if: ${{ matrix.operating-system == 'ubuntu-latest' }}
         run: |
-          docker run --name snmpd -d -p 10161:161/udp polinux/snmpd
+          docker run \
+              --name snmpd \
+              -d \
+              -p 10161:161/udp \
+              -v "$(pwd)/tests/resources/snmpd.conf":/etc/snmpd/snmpd.custom.conf \
+              polinux/snmpd \
+              -c /etc/snmpd/snmpd.custom.conf
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Static Analysis
         run: composer analyse
 
-  unit-tests:
+  tests:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
@@ -50,48 +50,8 @@ jobs:
           tools: composer:v2
           coverage: pcov
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Install Composer dependencies
-        if: ${{ matrix.php-versions != '8.1' }}
-        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
-
-      - name: Install Composer dependencies (8.1)
-        if: ${{ matrix.php-versions == '8.1' }}
-        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader --ignore-platform-reqs
-
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Run Tests
-        run: composer test-spec
-
-  integration-tests:
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ubuntu-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-    name: Integration Tests for PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          tools: composer:v2
-          coverage: pcov
-
       - name: Start SNMP Container
+        if: ${{ matrix.operating-system == 'ubuntu-latest' }}
         run: |
           docker run --name snmpd -d -p 10161:161/udp polinux/snmpd
 
@@ -114,5 +74,9 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Run Tests
+      - name: Run Unit Tests
+        run: composer test-spec
+
+      - name: Run Integration Tests
+        if: ${{ matrix.operating-system == 'ubuntu-latest' }}
         run: composer test-integration

--- a/tests/integration/FreeDSx/Snmp/SnmpWalkTest.php
+++ b/tests/integration/FreeDSx/Snmp/SnmpWalkTest.php
@@ -15,7 +15,7 @@ class SnmpWalkTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->client = $this->makeReadOnlyClient();
+        $this->client = $this->makeClient();
     }
 
     public function testItWalksAllOids()

--- a/tests/integration/FreeDSx/Snmp/TestCase.php
+++ b/tests/integration/FreeDSx/Snmp/TestCase.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    public function makeReadOnlyClient(array $options = []): SnmpClient
+    public function makeClient(array $options = []): SnmpClient
     {
         return new SnmpClient(array_merge(
             $this->defaultOptions(),

--- a/tests/resources/snmpd.conf
+++ b/tests/resources/snmpd.conf
@@ -1,0 +1,35 @@
+####
+# First, map the community name "public" into a "security name"
+
+#       sec.name  source          community
+com2sec notConfigUser  default       public
+com2sec configUser     default       secret
+
+####
+# Second, map the security name into a group name:
+
+#       groupName      securityModel securityName
+group   notConfigGroup v1            notConfigUser
+group   notConfigGroup v2c           notConfigUser
+group   configGroup    v2c           configUser
+
+####
+# Third, create a view for us to let the group have rights to:
+
+# Make at least  snmpwalk -v 1 localhost -c public system fast again.
+#       name           incl/excl     subtree         mask(optional)
+view    systemview    included   .1.3.6.1.2.1.1
+view    systemview    included   .1.3.6.1.2.1.25.1.1
+view    all           included   .1
+
+####
+# Finally, grant the group read-only access to the systemview view.
+
+#       group          context sec.model sec.level prefix read   write  notif
+access  notConfigGroup ""      any       noauth    exact  systemview none       none
+access  configGroup    ""      any       noauth    exact  all        all        none
+
+syslocation Unknown (edit /etc/snmp/snmpd.conf)
+syscontact Root <root@localhost> (configure /etc/snmp/snmp.local.conf)
+
+dontLogTCPWrappersConnects yes


### PR DESCRIPTION
This adjusts integration tests in a few ways:

* Consolidate test runs so it runs after unit tests but only during the "ubuntu-latest" runs.
* Use a custom snmpd.conf file.
* Add a "set" test. Though there appears to be some docker / snmpd config related issue prevent a good set test.