### PR TITLE
feature: add support for PHP 8.4, Implicitly marking parameter as nul…

### DIFF
--- a/src/FreeDSx/Snmp/SnmpClient.php
+++ b/src/FreeDSx/Snmp/SnmpClient.php
@@ -251,8 +251,8 @@ class SnmpClient
      * @return SnmpWalk
      */
     public function walk(
-        string $startAt = null,
-        string $endAt = null
+        ?string $startAt = null,
+        ?string $endAt = null
     ): SnmpWalk {
         return new SnmpWalk(
             $this,


### PR DESCRIPTION
SnmpClient gives deprication warning when using walk method.

PHP 8.4 has depricated the following: implicitly marking parameter as nullable

https://dev.to/gromnan/fix-php-84-deprecation-implicitly-marking-parameter-as-nullable-is-deprecated-the-explicit-nullable-type-must-be-used-instead-5gp3