### PR TITLE
Lock FreeDSx dependencies to avoid conflicts with a 1.0 release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     name: Static Analysis
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -16,13 +16,14 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
       - name: Cache Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -37,11 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.2']
     name: Unit Tests for PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -63,18 +64,14 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Install Composer dependencies
-        if: ${{ matrix.php-versions != '8.1' }}
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
-      - name: Install Composer dependencies (8.1)
-        if: ${{ matrix.php-versions == '8.1' }}
-        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader --ignore-platform-reqs
-
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+0.5.1 (2026-04-25)
+------------------
+* Lock FreeDSx dependencies to avoid conflicts with a 1.0 release.
+
 0.5.0 (2022-01-29)
 ------------------
 * Many static analysis fixes. The PhpStan level is now set to max.

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
   ],
   "require": {
     "php": ">=7.1",
-    "freedsx/asn1": ">=0.4.0",
-    "freedsx/socket": ">=0.3.0"
+    "freedsx/asn1": ">=0.4,<1.0",
+    "freedsx/socket": ">=0.3,<1.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2",

--- a/src/FreeDSx/Snmp/Value/AbstractValue.php
+++ b/src/FreeDSx/Snmp/Value/AbstractValue.php
@@ -28,6 +28,9 @@ abstract class AbstractValue implements ProtocolElementInterface
 
     protected const ASN1_TAG = null;
 
+    /**
+     * @var class-string<AbstractType>
+     */
     protected const ASN1_CLASS = null;
 
     /**


### PR DESCRIPTION
Locking the dependencies here as I prepare for a 1.0 release in the LDAP library. I'm updating deps to avoid the >= constraint that is causing issues. Constraints will be more locked down going forward.