### PR TITLE
Fix PHP 8.4 nullable type deprecation in exception constructor

### DIFF
--- a/src/FreeDSx/Snmp/Exception/SnmpRequestException.php
+++ b/src/FreeDSx/Snmp/Exception/SnmpRequestException.php
@@ -54,7 +54,7 @@ class SnmpRequestException extends \Exception
      * @param null|string $message
      * @param \Throwable|null $previous
      */
-    public function __construct(?MessageResponseInterface $response, ?string $message = null, \Throwable $previous = null)
+    public function __construct(?MessageResponseInterface $response, ?string $message = null, ?\Throwable $previous = null)
     {
         $this->snmpMessage = $response;
         $errorCode = $response ? $response->getResponse()->getErrorStatus() : 0;


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters. The `$previous` parameter in the constructor defaults to `null` but is not typed as nullable. Adding `?` before `\Throwable` resolves the deprecation.

This is similar to the fix applied in v0.5.2 for the `walk()` method.